### PR TITLE
Set content-type header before call to WriteHeader (or Write)

### DIFF
--- a/context/response.go
+++ b/context/response.go
@@ -74,9 +74,9 @@ func (r *Response) Send(w http.ResponseWriter) {
 		http.SetCookie(w, cookie)
 	}
 
-	w.WriteHeader(r.GetCode())
-
 	w.Header().Set("Content-Type", r.GetContentType()+";"+" charset="+r.GetCharset())
+
+	w.WriteHeader(r.GetCode())
 
 	w.Write([]byte(r.GetContent()))
 }


### PR DESCRIPTION
Set the content-type header before any call to WriteHeader or Write, otherwise it is just ignored. Fixes #2

Looks like golang does some auto content-type detection or something. Html pages still get the 'text/html' content-type header, even if you remove the set header line. But if you make f.e. a new Response and set the content-type to 'text/css' it will return a 'text/plain' content-type header instead.

From the golang documentation for ResponseWriter.Header():

> Changing the header map after a call to WriteHeader (or Write) has no effect unless the modified headers are trailers.